### PR TITLE
Callbacks de colisiones y rigidbodys como triggers

### DIFF
--- a/FORGE/projects/Demo/Demo.vcxproj
+++ b/FORGE/projects/Demo/Demo.vcxproj
@@ -118,10 +118,18 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\Demo\Move.cpp">
+      <SubType>
+      </SubType>
+    </ClCompile>
     <ClCompile Include="..\..\src\Demo\prueba.cpp" />
     <ClCompile Include="..\..\src\Demo\TestMovement.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\Demo\Move.h">
+      <SubType>
+      </SubType>
+    </ClInclude>
     <ClInclude Include="..\..\src\Demo\prueba.h" />
     <ClInclude Include="..\..\src\Demo\TestMovement.h" />
   </ItemGroup>

--- a/FORGE/projects/Demo/Demo.vcxproj.filters
+++ b/FORGE/projects/Demo/Demo.vcxproj.filters
@@ -21,12 +21,18 @@
     <ClCompile Include="..\..\src\Demo\TestMovement.cpp">
       <Filter>Archivos de origen</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Demo\Move.cpp">
+      <Filter>Archivos de origen</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Demo\TestMovement.h">
       <Filter>Archivos de encabezado</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Demo\prueba.h">
+      <Filter>Archivos de encabezado</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Demo\Move.h">
       <Filter>Archivos de encabezado</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FORGE/projects/Demo/resources.cfg
+++ b/FORGE/projects/Demo/resources.cfg
@@ -1,6 +1,6 @@
 # Ogre Core Resources
 [OgreInternal]
-FileSystem=C:/hlocal/FORGE\FORGE/Dependencies/Ogre/src/Samples/Media/models/
-FileSystem=C:/hlocal/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/scripts
-FileSystem=C:/hlocal/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/textures
-FileSystem=C:/hlocal/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/programs
+FileSystem=C:/Users/49leg/Documents/GitHub/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/models/
+FileSystem=C:/Users/49leg/Documents/GitHub/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/scripts
+FileSystem=C:/Users/49leg/Documents/GitHub/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/textures
+FileSystem=C:/Users/49leg/Documents/GitHub/FORGE/FORGE/Dependencies/Ogre/src/Samples/Media/materials/programs

--- a/FORGE/projects/Demo/scenetest.lua
+++ b/FORGE/projects/Demo/scenetest.lua
@@ -30,13 +30,16 @@ local scenes = {
             handler = "menace",
             components = {
                 Transform = {
-                    position = {0, -10, 0}
+                    position = {0, 10, 0}
                 },
                 Mesh = {
                     mesh = "ogrehead.mesh"
                 },
                 TestMovement = {
                     name = "maincam"
+                },
+                Move = {
+                    speed = 10
                 },
                 RigidBody = {
                     scale = {1, 1, 1},
@@ -51,11 +54,18 @@ local scenes = {
             group = "obstacle",
             components = {
                 Transform = {
-                    position = {10, 0, -10},
+                    position = {0, 0, 0},
                     scale = {5, 5, 5}
                 },
                 Mesh = {
                     mesh = "Barrel.mesh"
+                },
+                RigidBody = {
+                    scale = {1, 1, 1},
+                    mass = 0.1,
+                    friction = 0.5,
+                    restitution = 0.6,
+                    shapeType = "Box"
                 }
             }
         },

--- a/FORGE/projects/Demo/scenetest.lua
+++ b/FORGE/projects/Demo/scenetest.lua
@@ -38,15 +38,15 @@ local scenes = {
                 TestMovement = {
                     name = "maincam"
                 },
-                Move = {
-                    speed = 10
-                },
                 RigidBody = {
                     scale = {1, 1, 1},
                     mass = 0.1,
                     friction = 0.5,
                     restitution = 0.6,
                     shapeType = "Box"
+                },
+                Move = {
+                    speed = 1
                 }
             }
         },

--- a/FORGE/src/Demo/Move.cpp
+++ b/FORGE/src/Demo/Move.cpp
@@ -1,0 +1,20 @@
+#include "Move.h"
+#include "ComponentData.h"
+#include "Serializer.h"
+#include "RigidBody.h"
+#include "Entity.h"
+
+const std::string Move::id = "Move";
+
+Move::Move() {
+
+}
+
+void Move::initComponent(ComponentData* data) {
+	rb = entity->getComponent<RigidBody>();
+	movement = data->get<float>("speed");
+}
+
+void Move::update() {
+	rb->applyForce(forge::Vector3(0, movement, 0));
+}

--- a/FORGE/src/Demo/Move.cpp
+++ b/FORGE/src/Demo/Move.cpp
@@ -13,6 +13,7 @@ Move::Move() {
 void Move::initComponent(ComponentData* data) {
 	rb = entity->getComponent<RigidBody>();
 	movement = data->get<float>("speed");
+	rb->setTrigger(true);
 }
 
 void Move::update() {

--- a/FORGE/src/Demo/Move.h
+++ b/FORGE/src/Demo/Move.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "Component.h"
+class RigidBody;
+class Move : public Component {
+public:
+	static const std::string id;	
+	/// <summary>
+	/// Constructora por defecto del component Move
+	/// </summary>
+	Move();
+	/// <summary>
+	/// Se llama en la creacion del componente Move
+	/// </summary>
+	/// <param name="data">Bloque con la informacion guardada para el componente</param>
+	void initComponent(ComponentData* data) override;
+	/// <summary>
+	/// Actualiza la logica del componente, llamandose en cada iteracion del bucle principal
+	/// </summary>
+	void update() override;
+
+	private:
+		float movement = 10.0f;
+		RigidBody* rb;
+
+};

--- a/FORGE/src/Demo/TestMovement.cpp
+++ b/FORGE/src/Demo/TestMovement.cpp
@@ -1,6 +1,7 @@
 ﻿#include "TestMovement.h"
 #include "Input.h"
 #include "Transform.h"
+#include "Rigidbody.h"
 #include "ComponentData.h"
 #include "Entity.h"
 
@@ -13,6 +14,12 @@ TestMovement::TestMovement() :
 
 void TestMovement::initComponent(ComponentData* data) {
 	transform = entity->getComponent<Transform>();
+
+	//aprovecho para probar callbacks tmb uwu
+	entity->getComponent<RigidBody>()->registerCallback([] (RigidBody* self, RigidBody* other) {
+		std::cout << "Colisiono con algo\n";
+	});
+
 }
 
 void TestMovement::update() {

--- a/FORGE/src/Demo/prueba.cpp
+++ b/FORGE/src/Demo/prueba.cpp
@@ -19,6 +19,7 @@
 #include "test.h"
 #include "PhysicsManager.h"
 #include "RigidBody.h"
+#include "Move.h"
 
 #define FIXED_UPDATE_RATE 20
 
@@ -30,6 +31,7 @@ void factory() {
 	f.registerComponent<Camera>();
 	f.registerComponent<TestMovement>();
 	f.registerComponent<RigidBody>();
+	f.registerComponent<Move>();
 }
 
 

--- a/FORGE/src/Physics/PhysicsManager.cpp
+++ b/FORGE/src/Physics/PhysicsManager.cpp
@@ -32,6 +32,40 @@ void PhysicsManager::initPhysics() {
 
 void PhysicsManager::updatePhysics() {
     world->stepSimulation(1 / 50.f, 20);
+    handleCollisions();    
+}
+
+void PhysicsManager::handleCollisions() {
+    //Iteramos en todos los manifolds ocurridos en la ultima simulacion
+    int numManifolds = dispatcher->getNumManifolds();
+
+    for (int i = 0; i < numManifolds; i++) {
+        //Obtenemos el manifold actual
+		btPersistentManifold* contactManifold = dispatcher->getManifoldByIndexInternal(i);
+		const btCollisionObject* obA = contactManifold->getBody0();
+		const btCollisionObject* obB = contactManifold->getBody1();
+        //Iteramos en todos los contactos de cada manifold
+		int numContacts = contactManifold->getNumContacts();
+        for (int j = 0; j < numContacts; j++) {
+			btManifoldPoint& pt = contactManifold->getContactPoint(j);
+            if (pt.getDistance() < 0.f) {
+				const btVector3& ptA = pt.getPositionWorldOnA();
+				const btVector3& ptB = pt.getPositionWorldOnB();
+				const btVector3& normalOnB = pt.m_normalWorldOnB;
+				//std::cout << "Collision at: " << ptA.getX() << " " << ptA.getY() << " " << ptA.getZ() << std::endl;
+				//std::cout << "Collision at: " << ptB.getX() << " " << ptB.getY() << " " << ptB.getZ() << std::endl;
+				//std::cout << "Collision normal: " << normalOnB.getX() << " " << normalOnB.getY() << " " << normalOnB.getZ() << std::endl;
+            }
+            //Llamamos a los callbacks que tenga guardados el componente Rigidbody de cada objeto
+            auto auxTransformA = transforms.find((btRigidBody*)obA);
+            auto auxTransformB = transforms.find((btRigidBody*)obB);
+            if (auxTransformA != transforms.end() &&  auxTransformB != transforms.end()) {
+				auxTransformA->second->getEntity()->getComponent<RigidBody>()->onCollision(auxTransformB->second->getEntity());
+			
+				auxTransformB->second->getEntity()->getComponent<RigidBody>()->onCollision(auxTransformA->second->getEntity());
+			}
+		}
+	}
 }
 
 void PhysicsManager::changeGravity(forge::Vector3 newGravity) {

--- a/FORGE/src/Physics/PhysicsManager.h
+++ b/FORGE/src/Physics/PhysicsManager.h
@@ -38,6 +38,11 @@ public:
     /// </summary>
     void updatePhysics();
     
+    /// <summary>
+    /// Comprueba las colisiones ocurridas en la ultima simulacion y las resuelve segun los callbacks definidos.
+    /// </summary>
+    void handleCollisions();
+
     void changeGravity(forge::Vector3 newGravity);
 
     /// <returns>Devuelve una instancia al PhysicsManager</returns>

--- a/FORGE/src/Physics/RigidBody.cpp
+++ b/FORGE/src/Physics/RigidBody.cpp
@@ -87,6 +87,10 @@ bool RigidBody::hasCollidedWith(RigidBody* other) {
     return myBody->checkCollideWith(other->getBody());
 }
 
+void RigidBody::registerCallback(CollisionCallback callback) {
+    collisionCallbacks.push_back(callback);
+}
+
 void RigidBody::setFriction(float newFriction) {
     
     friction = newFriction;
@@ -147,6 +151,12 @@ forge::Vector3 RigidBody::getRigidScale() {
 
 btRigidBody* RigidBody::getBody(){
     return myBody;
+}
+
+void RigidBody::onCollision(Entity* other) {
+    for (auto cb : collisionCallbacks) {
+        cb(this, other->getComponent<RigidBody>());
+    }
 }
 
 

--- a/FORGE/src/Physics/RigidBody.cpp
+++ b/FORGE/src/Physics/RigidBody.cpp
@@ -141,6 +141,19 @@ bool RigidBody::isStatic() {
     return staticBody;
 }
 
+bool RigidBody::isTrigger() {
+    return trigger;
+}
+
+void RigidBody::setTrigger(bool isTrigger) {
+    trigger = isTrigger;
+    if (trigger)
+		myBody->setCollisionFlags(myBody->getCollisionFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
+	else
+        myBody->setCollisionFlags(myBody->getCollisionFlags() & ~btCollisionObject::CF_NO_CONTACT_RESPONSE);
+    
+}
+
 btCollisionShape* RigidBody::getShape() {
     return myShape;
 }

--- a/FORGE/src/Physics/RigidBody.h
+++ b/FORGE/src/Physics/RigidBody.h
@@ -15,9 +15,12 @@ enum collisionShape
 };
 namespace forge {
     class Vector3;
+    
 };
 
 class RigidBody : public Component {
+
+    using CollisionCallback = void(*)(RigidBody* self, RigidBody* other);
 private:
     PhysicsManager* physicsManager;
     float mass;
@@ -29,8 +32,11 @@ private:
     btCollisionShape* myShape;
     collisionShape shapeType;
     forge::Vector3 myScale;
+    std::vector<CollisionCallback> collisionCallbacks;
 
     btRigidBody* getBody();
+
+    
 public:
     static const std::string id;
 
@@ -49,6 +55,17 @@ public:
     void clearForces();
 
     bool hasCollidedWith(RigidBody* other);
+
+    /// <summary>
+    /// Registra un nuevo callback de colision
+    /// </summary>
+    void registerCallback(CollisionCallback callback);
+
+    /// <summary>
+    /// Maneja las colisiones con otros cuerpos rigidos
+    /// </summary>
+    /// <param name="other"></param>
+    void onCollision(Entity* other);
     #pragma region setters
     void setFriction(float newFriction);
 

--- a/FORGE/src/Physics/RigidBody.h
+++ b/FORGE/src/Physics/RigidBody.h
@@ -28,6 +28,7 @@ private:
     float restitution;
     bool kinematic;
     bool staticBody;
+    bool trigger;
     btRigidBody* myBody;
     btCollisionShape* myShape;
     collisionShape shapeType;
@@ -86,6 +87,10 @@ public:
     float getRestitution();
 
     bool isStatic();
+
+    bool isTrigger();
+
+    void setTrigger(bool isTrigger);
 
     btCollisionShape* getShape();
 


### PR DESCRIPTION
Hay partes todavía sin comentar, cuando se revise guay lo comento todo, este PR incluye lo siguiente:

- Interfaz de añadido de callbacks para lógica customizable
- La capacidad de hacer un elemento trigger, no aplica fuerzas de colisión pero detecta las colisiones
- Una prueba pequeña para probar las funcionalidades desde los componentes Move y TestMovement.